### PR TITLE
Add image upload limits to book forms

### DIFF
--- a/src/components/books/AddNewBook.jsx
+++ b/src/components/books/AddNewBook.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { toast } from 'react-toastify'
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { CustomeInputs } from '../CustomeInputs'
@@ -7,10 +8,25 @@ import useForm from '@/hooks/useForm';
 import { addNewBook, getBooks } from '@/axio/axioHelper';
 // import { useDispatch, useSelector } from 'react-redux'
 import { setBook } from '@/redux/books/bookSlice';
-const initialState = {}
+const initialState = { coverImage: null }
 const AddNewBook = () => {
     // const dispatch = useDispatch()
     const { form, setForm, handleOnChange } = useForm(initialState);
+
+    const handleFileChange = (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const allowed = ['image/png', 'image/jpeg', 'image/jpg'];
+        if (!allowed.includes(file.type)) {
+            alert('Please upload only png, jpeg or jpg images.');
+            return;
+        }
+        if (file.size > 2 * 1024 * 1024) {
+            alert('Image size should not exceed 2MB.');
+            return;
+        }
+        setForm({ ...form, coverImage: file });
+    };
     const handleOnSubmit = async (e) => {
         e.preventDefault();
         console.log(form.ExpectedDateAvailable)
@@ -30,7 +46,7 @@ const AddNewBook = () => {
             <hr></hr>
             <div>
                 <Form onSubmit={handleOnSubmit}>
-                    {
+                    { 
                         bookFormFields.map((input) =>
                             <CustomeInputs
                                 key={input.name}
@@ -40,6 +56,10 @@ const AddNewBook = () => {
                             </CustomeInputs>
                         )
                     }
+                    <Form.Group className="mb-3" controlId="bookImage">
+                        <Form.Label>Book Image</Form.Label>
+                        <Form.Control type="file" accept="image/png,image/jpeg,image/jpg" onChange={handleFileChange} />
+                    </Form.Group>
                     <Button variant="primary" type="submit">
                         Submit
                     </Button>

--- a/src/components/books/BookTable.jsx
+++ b/src/components/books/BookTable.jsx
@@ -15,6 +15,8 @@ const BookTable = () => {
     const dispatch = useDispatch();
     const [show, setShow] = useState(false);
     const [selectedBook, setSelectedBook] = useState({});
+    const [images, setImages] = useState([]);
+    const [thumbnailIndex, setThumbnailIndex] = useState(null);
     const fetchBooks = async () => {
         try {
             const result = await getBooks();
@@ -42,6 +44,30 @@ const BookTable = () => {
     const handleClose = () => {
         setShow(false);
         setSelectedBook({});
+    };
+    const handleImageUpload = (e) => {
+        const files = Array.from(e.target.files || []);
+        if (files.length + images.length > 5) {
+            alert('You can upload a maximum of 5 images.');
+            return;
+        }
+        const allowed = ['image/png', 'image/jpeg', 'image/jpg'];
+        const validFiles = [];
+        for (const file of files) {
+            if (!allowed.includes(file.type)) {
+                alert('Only png, jpeg or jpg images are allowed.');
+                continue;
+            }
+            if (file.size > 2 * 1024 * 1024) {
+                alert('Each image must be less than 2MB.');
+                continue;
+            }
+            validFiles.push(file);
+        }
+        setImages(prev => [...prev, ...validFiles]);
+    };
+    const handleThumbnailSelect = (index) => {
+        setThumbnailIndex(index);
     };
     // Handle form change
     const handleChange = (e) => {
@@ -202,6 +228,27 @@ const BookTable = () => {
                                 <option value="unavailable">Unavailable</option>
                             </Form.Select>
                         </Form.Group>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Upload Images</Form.Label>
+                            <Form.Control type="file" multiple accept="image/png,image/jpeg,image/jpg" onChange={handleImageUpload} />
+                        </Form.Group>
+                        {images.length > 0 && (
+                            <div className="d-flex flex-wrap">
+                                {images.map((img, idx) => (
+                                    <div key={idx} className="m-2 text-center">
+                                        <img src={URL.createObjectURL(img)} alt="preview" width="80" />
+                                        <Form.Check
+                                            type="radio"
+                                            name="thumbnail"
+                                            label="Thumbnail"
+                                            className="mt-1"
+                                            checked={thumbnailIndex === idx}
+                                            onChange={() => handleThumbnailSelect(idx)}
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        )}
 
                     </Modal.Body>
                     <Modal.Footer>


### PR DESCRIPTION
## Summary
- allow uploading a cover image when creating a book
- enforce image file type and 2MB limit
- enable uploading up to 5 images in edit modal
- select a thumbnail image from uploaded images

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6856958c5e1483208d05eead89d0aab9